### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/systopia/Contact-Update-Queue/issues</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>0.6-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>Funded by Amnesty International Vlaanderen</comments>
   <classloader>

--- a/templates/CRM/I3val/Form/Configuration.tpl
+++ b/templates/CRM/I3val/Form/Configuration.tpl
@@ -51,18 +51,18 @@
 <h3>{ts domain="be.aivl.i3val"}Update Request Options{/ts}</h3>
 <div>
   <div class="crm-section">
-    <div class="label">{$form.allow_clearing.label}&nbsp;<a onclick='CRM.help("{ts domain="be.aivl.i3val"}Clearing Fields{/ts}", {literal}{"id":"id-field-clearing","file":"CRM\/I3val\/Form\/Configuration"}{/literal}); return false;' href="#" title="{ts domain="be.aivl.i3val"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="label">{$form.allow_clearing.label}&nbsp;<a onclick='CRM.help("{ts escape="htmlattribute" domain="be.aivl.i3val"}Clearing Fields{/ts}", {literal}{"id":"id-field-clearing","file":"CRM\/I3val\/Form\/Configuration"}{/literal}); return false;' href="#" title="{ts escape="htmlattribute" domain="be.aivl.i3val"}Help{/ts}" class="helpicon">&nbsp;</a></div>
     <div class="content">{$form.allow_clearing.html}</div>
     <div class="clear"></div>
   </div>
   <div class="crm-section">
-    <div class="label">{$form.strip_chars.label}&nbsp;<a onclick='CRM.help("{ts domain="be.aivl.i3val"}Strip Characters{/ts}", {literal}{"id":"id-strip-chars","file":"CRM\/I3val\/Form\/Configuration"}{/literal}); return false;' href="#" title="{ts domain="be.aivl.i3val"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="label">{$form.strip_chars.label}&nbsp;<a onclick='CRM.help("{ts escape="htmlattribute" domain="be.aivl.i3val"}Strip Characters{/ts}", {literal}{"id":"id-strip-chars","file":"CRM\/I3val\/Form\/Configuration"}{/literal}); return false;' href="#" title="{ts escape="htmlattribute" domain="be.aivl.i3val"}Help{/ts}" class="helpicon">&nbsp;</a></div>
     <div class="content">{$form.strip_chars.html}</div>
     <div class="clear"></div>
   </div>
 
   <div class="crm-section">
-    <div class="label">{$form.empty_token.label}&nbsp;<a onclick='CRM.help("{ts domain="be.aivl.i3val"}Empty Token{/ts}", {literal}{"id":"id-empty-token","file":"CRM\/I3val\/Form\/Configuration"}{/literal}); return false;' href="#" title="{ts domain="be.aivl.i3val"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+    <div class="label">{$form.empty_token.label}&nbsp;<a onclick='CRM.help("{ts escape="htmlattribute" domain="be.aivl.i3val"}Empty Token{/ts}", {literal}{"id":"id-empty-token","file":"CRM\/I3val\/Form\/Configuration"}{/literal}); return false;' href="#" title="{ts escape="htmlattribute" domain="be.aivl.i3val"}Help{/ts}" class="helpicon">&nbsp;</a></div>
     <div class="content">{$form.empty_token.html}</div>
     <div class="clear"></div>
   </div>

--- a/templates/CRM/I3val/Handler/AddressUpdate.tpl
+++ b/templates/CRM/I3val/Handler/AddressUpdate.tpl
@@ -19,17 +19,17 @@
           <td style="vertical-align: middle;">{$fieldlabel}</td>
           <td style="vertical-align: middle;">
             {if $i3val_address_values.$fieldkey.original}
-              <img class="action-icon address-value-copy" value="{$i3val_address_values.$fieldkey.original}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_address_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_address_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon address-value-copy" value="{$i3val_address_values.$fieldkey.original}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_address_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_address_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_address_values.$fieldkey.original}</td>
           <td style="vertical-align: middle;">
             {if $i3val_address_values.$fieldkey.submitted}
-              <img class="action-icon address-value-copy" value="{$i3val_address_values.$fieldkey.submitted}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_address_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_address_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon address-value-copy" value="{$i3val_address_values.$fieldkey.submitted}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_address_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_address_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_address_values.$fieldkey.submitted}
           </td>
           <td class="i3val-address-current i3val-address-current-{$fieldkey}" style="vertical-align: middle;">
-            <img style="display: none;" class="action-icon address-value-copy" value="{$i3val_address_values.$fieldkey.current}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_address_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_address_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" />
+            <img style="display: none;" class="action-icon address-value-copy" value="{$i3val_address_values.$fieldkey.current}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_address_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_address_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" />
             <span>{$i3val_address_values.$fieldkey.current}</span>
           </td>
           <td style="vertical-align: middle;" class="i3val-control">{$form.$input_field.html}</td>

--- a/templates/CRM/I3val/Handler/EmailUpdate.tpl
+++ b/templates/CRM/I3val/Handler/EmailUpdate.tpl
@@ -19,19 +19,19 @@
           <td style="vertical-align: middle;">{$fieldlabel}</td>
           <td style="vertical-align: middle;">
             {if $i3val_email_values.$fieldkey.original}
-              <img class="action-icon phone-value-copy" value="{$i3val_email_values.$fieldkey.original}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_email_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_email_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon phone-value-copy" value="{$i3val_email_values.$fieldkey.original}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_email_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_email_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_email_values.$fieldkey.original}
           </td>
           <td style="vertical-align: middle;">
             {if $i3val_email_values.$fieldkey.submitted}
-              <img class="action-icon phone-value-copy" value="{$i3val_email_values.$fieldkey.submitted}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_email_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_email_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon phone-value-copy" value="{$i3val_email_values.$fieldkey.submitted}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_email_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_email_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_email_values.$fieldkey.submitted}
           </td>
           <td style="vertical-align: middle;">
             {if $i3val_email_values.$fieldkey.current}
-              <img class="action-icon phone-value-copy" value="{$i3val_email_values.$fieldkey.current}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_email_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_email_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon phone-value-copy" value="{$i3val_email_values.$fieldkey.current}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_email_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_email_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_email_values.$fieldkey.current}
           </td>

--- a/templates/CRM/I3val/Handler/PhoneUpdate.tpl
+++ b/templates/CRM/I3val/Handler/PhoneUpdate.tpl
@@ -19,19 +19,19 @@
           <td style="vertical-align: middle;">{$fieldlabel}</td>
           <td style="vertical-align: middle;">
             {if $i3val_phone_values.$fieldkey.original}
-              <img class="action-icon phone-value-copy" value="{$i3val_phone_values.$fieldkey.original}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_phone_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_phone_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon phone-value-copy" value="{$i3val_phone_values.$fieldkey.original}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_phone_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_phone_values.$fieldkey.original}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_phone_values.$fieldkey.original}
           </td>
           <td style="vertical-align: middle;">
             {if $i3val_phone_values.$fieldkey.submitted}
-              <img class="action-icon phone-value-copy" value="{$i3val_phone_values.$fieldkey.submitted}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_phone_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_phone_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon phone-value-copy" value="{$i3val_phone_values.$fieldkey.submitted}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_phone_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_phone_values.$fieldkey.submitted}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_phone_values.$fieldkey.submitted}
           </td>
           <td style="vertical-align: middle;">
             {if $i3val_phone_values.$fieldkey.current}
-              <img class="action-icon phone-value-copy" value="{$i3val_phone_values.$fieldkey.current}" src="{$i3val_icon_copy}" alt="{ts 1=$i3val_phone_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts 1=$i3val_phone_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" />
+              <img class="action-icon phone-value-copy" value="{$i3val_phone_values.$fieldkey.current}" src="{$i3val_icon_copy}" alt="{ts escape="htmlattribute" 1=$i3val_phone_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" title="{ts escape="htmlattribute" 1=$i3val_phone_values.$fieldkey.current}Click to copy '%1' into the 'apply' column.{/ts}" />
             {/if}
             {$i3val_phone_values.$fieldkey.current}
           </td>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.